### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting Security Vulnerabilities
+
+To report a security vulnerability, please send a detailed disclosure to security@lists.chipsalliance.org. This is a confidential mailing list, and the TAC chair and a small group of trusted individuals will review and act upon the report as appropriate.


### PR DESCRIPTION
Adding a default vulnerability reporting policy, to match what's used in the CHIPS Alliance org.